### PR TITLE
Fix race condition when using the code cache

### DIFF
--- a/gin/core/controller.lua
+++ b/gin/core/controller.lua
@@ -8,13 +8,12 @@ local Controller = {}
 Controller.__index = Controller
 
 function Controller.new(request, params)
-    params = params or {}
+    local p = params or {}
 
     local instance = {
-        params = params,
+        params = p,
         request = request
     }
-    setmetatable(instance, Controller)
     return instance
 end
 

--- a/gin/core/router.lua
+++ b/gin/core/router.lua
@@ -122,11 +122,12 @@ end
 function Router.call_controller(request, controller_name, action, params)
     -- load matched controller and set metatable to new instance of controller
     local matched_controller = require(controller_name)
+    setmetatable(matched_controller, Controller)
     local controller_instance = Controller.new(request, params)
-    setmetatable(matched_controller, { __index = controller_instance })
+    setmetatable(controller_instance, {__index = matched_controller}) 
 
     -- call action
-    local ok, status_or_error, body, headers = pcall(function() return matched_controller[action](matched_controller) end)
+    local ok, status_or_error, body, headers = pcall(function() return controller_instance[action](controller_instance) end)
 
     local response
 

--- a/gin/db/sql/common/orm.lua
+++ b/gin/db/sql/common/orm.lua
@@ -85,7 +85,13 @@ function SqlCommonOrm:where(attrs, options)
     -- init sql
     local sql = {}
     -- start
-    tappend(sql, "SELECT * FROM ")
+    if not options.select then
+	    tappend(sql, "SELECT * FROM ")
+    else
+	    tappend(sql, "SELECT ")
+	    tappend(sql, tconcat(options.select, ","))
+	    tappend(sql, " FROM ")
+    end
     tappend(sql, self.table_name)
     -- where
     build_where(self, sql, attrs)

--- a/gin/db/sql/orm.lua
+++ b/gin/db/sql/orm.lua
@@ -51,6 +51,9 @@ function SqlOrm.define_model(sql_database, table_name)
         if options and options.order then
             merged_options.order = options.order
         end
+	if options and options.select then
+            merged_options.select = options.select
+	end
 
         return GinModel.where(attrs, merged_options)[1]
     end


### PR DESCRIPTION
require()s are evaluated only once.
Each time we require a user-generated controller module,
in production mode (with code cache enabled) it returns the *same*
table.
http://wiki.nginx.org/HttpLuaModule#Data_Sharing_within_an_Nginx_Worker

If we use  setmetatable() to "inject" the request data to use in the controller,
and the coroutine yields (blocked in IO for example), and another
request come in for that controller in the same worker process, then it
will *override* the request data of the previous one.

Simple scenario:

function MyController:MyMethod()
	local myUriParam = self.params[1]

	sleep() / block on IO

	local body = self.request.body
		-- Problem!  it could be the body of another request!
		-- myUriParam  can be different than self.params[1] now
)

The solution was to chain the metatables in the other direction:
set the user controller as the metatable of the request instance.
The user controller itself has a metatable the Gin' controller
(for now I'm setting it every time, but pretty sure that could be done
 only once at setup time when generating the routes)