### PR TITLE
Try to address issue #15

### DIFF
--- a/gin/db/sql/mysql/adapter.lua
+++ b/gin/db/sql/mysql/adapter.lua
@@ -99,17 +99,18 @@ function MySql.execute(options, sql)
     return res
 end
 
--- execute a query and return the last ID
-function MySql.execute_and_return_last_id(options, sql)
+--- Execute a query and return the last ID
+function MySql.execute_and_return_last_id(options, sql, id_col)
     -- get db object
     local db = mysql_connect(options)
     -- execute query
     db_execute(options, db, sql)
     -- get last id
-    local res = db_execute(options, db, "SELECT LAST_INSERT_ID() AS id;")
+    local id_col = id_col
+    local res = db_execute(options, db, "SELECT LAST_INSERT_ID() AS " .. id_col .. ";")
     -- keepalive
     mysql_keepalive(db, options)
-    return tonumber(res[1].id)
+    return tonumber(res[1][id_col])
 end
 
 return MySql

--- a/gin/db/sql/mysql/adapter_detached.lua
+++ b/gin/db/sql/mysql/adapter_detached.lua
@@ -103,15 +103,15 @@ function MySql.execute(options, sql)
 end
 
 -- execute a query and return the last ID
-function MySql.execute_and_return_last_id(options, sql)
+function MySql.execute_and_return_last_id(options, sql, id_col)
     -- connect
     local db = mysql_connect(options)
     -- execute sql
     local sth, row = db_execute(db, sql)
     sth:close()
     -- get last id
-    local sth, row = db_execute(db, "SELECT BINARY LAST_INSERT_ID() as id;")
-    local id = row.id
+    local sth, row = db_execute(db, "SELECT BINARY LAST_INSERT_ID() AS " .. id_col .. ";")
+    local id = row[id_col]
     -- close
     sth:close()
     mysql_close(db)

--- a/gin/db/sql/orm.lua
+++ b/gin/db/sql/orm.lua
@@ -85,7 +85,7 @@ function SqlOrm.define_model(sql_database, table_name, id_col)
     end
 
     function GinModel:save()
-        local id_col = GinModel.__id_col or table_name .. '_id'
+        local id_col = GinModel.__id_col
         if self[id_col] ~= nil then
             local id = self[id_col]
             self[id_col] = nil

--- a/gin/db/sql/orm.lua
+++ b/gin/db/sql/orm.lua
@@ -5,9 +5,23 @@ local function tappend(t, v) t[#t+1] = v end
 
 local SqlOrm = {}
 
-function SqlOrm.define_model(sql_database, table_name)
+--- Define a model.
+-- The default primary key is set to 'id'
+-- @param sql_database the sql database instance
+-- @param table_name the name of the table to create a lightweight orm mapping for
+-- @param id_col set to true to use table_name .. '_id' as primary key,
+-- set to arbitrary string to use any other column as primary key
+function SqlOrm.define_model(sql_database, table_name, id_col)
     local GinModel = {}
     GinModel.__index = GinModel
+    if true == id_col then
+        id_col = table_name .. '_id'
+    elseif id_col then
+        id_col = tostring(id_col)
+    else
+        id_col = 'id' -- backward compatible default
+    end
+    GinModel.__id_col = id_col
 
     -- init
     local function quote(str)
@@ -23,10 +37,11 @@ function SqlOrm.define_model(sql_database, table_name)
 
     function GinModel.create(attrs)
         local sql = orm:create(attrs)
-        local id = sql_database:execute_and_return_last_id(sql)
+        local id_col = GinModel.__id_col
+        local id = sql_database:execute_and_return_last_id(sql, id_col)
 
         local model = GinModel.new(attrs)
-        model.id = id
+        model[id_col] = id
 
         return model
     end
@@ -70,11 +85,12 @@ function SqlOrm.define_model(sql_database, table_name)
     end
 
     function GinModel:save()
-        if self.id ~= nil then
-            local id = self.id
-            self.id = nil
-            local result = GinModel.update_where(self, { id = id })
-            self.id = id
+        local id_col = GinModel.__id_col or table_name .. '_id'
+        if self[id_col] ~= nil then
+            local id = self[id_col]
+            self[id_col] = nil
+            local result = GinModel.update_where(self, { [id_col] = id })
+            self[id_col] = id
             return result
         else
             return GinModel.create(self)

--- a/gin/db/sql/orm.lua
+++ b/gin/db/sql/orm.lua
@@ -86,8 +86,8 @@ function SqlOrm.define_model(sql_database, table_name, id_col)
 
     function GinModel:save()
         local id_col = GinModel.__id_col
-        if self[id_col] ~= nil then
-            local id = self[id_col]
+        local id = self[id_col]
+        if id ~= nil then
             self[id_col] = nil
             local result = GinModel.update_where(self, { [id_col] = id })
             self[id_col] = id
@@ -98,8 +98,10 @@ function SqlOrm.define_model(sql_database, table_name, id_col)
     end
 
     function GinModel:delete()
-        if self.id ~= nil then
-            return GinModel.delete_where({ id = self.id })
+        local id_col = GinModel.__id_col
+        local id = self[id_col]
+        if id ~= nil then
+            return GinModel.delete_where({ [id_col] = id })
         else
             error("cannot delete a model without an id")
         end

--- a/gin/db/sql/postgresql/adapter.lua
+++ b/gin/db/sql/postgresql/adapter.lua
@@ -97,9 +97,9 @@ local function append_to_sql(sql, append_sql)
 end
 
 -- execute a query and return the last ID
-function PostgreSql.execute_and_return_last_id(options, sql)
+function PostgreSql.execute_and_return_last_id(options, sql, id_col)
     -- execute query and get last id
-    sql = append_to_sql(sql, " RETURNING id;")
+    sql = append_to_sql(sql, " RETURNING " .. id_col .. ";")
     local res = db_execute(options, db, sql)
     return tonumber(res[1].id)
 end

--- a/gin/db/sql/postgresql/adapter.lua
+++ b/gin/db/sql/postgresql/adapter.lua
@@ -101,7 +101,7 @@ function PostgreSql.execute_and_return_last_id(options, sql, id_col)
     -- execute query and get last id
     sql = append_to_sql(sql, " RETURNING " .. id_col .. ";")
     local res = db_execute(options, db, sql)
-    return tonumber(res[1].id)
+    return tonumber(res[1][id_col])
 end
 
 return PostgreSql

--- a/gin/db/sql/postgresql/adapter_detached.lua
+++ b/gin/db/sql/postgresql/adapter_detached.lua
@@ -131,7 +131,7 @@ function PostgreSql.execute_and_return_last_id(options, sql, id_col)
     sql = append_to_sql(sql, " RETURNING " .. id_col .. ";")
     -- get last id
     local sth, row = db_execute(db, sql)
-    local id = row.id
+    local id = row[id_col]
     -- close
     sth:close()
     postgresql_close(db)

--- a/gin/db/sql/postgresql/adapter_detached.lua
+++ b/gin/db/sql/postgresql/adapter_detached.lua
@@ -124,11 +124,11 @@ local function append_to_sql(sql, append_sql)
 end
 
 -- execute a query and return the last ID
-function PostgreSql.execute_and_return_last_id(options, sql)
+function PostgreSql.execute_and_return_last_id(options, sql, id_col)
     -- connect
     local db = postgresql_connect(options)
     -- execute sql and get last id
-    sql = append_to_sql(sql, " RETURNING id;")
+    sql = append_to_sql(sql, " RETURNING " .. id_col .. ";")
     -- get last id
     local sth, row = db_execute(db, sql)
     local id = row.id

--- a/spec/db/sql/orm_spec.lua
+++ b/spec/db/sql/orm_spec.lua
@@ -90,6 +90,17 @@ describe("SqlOrm", function()
             it("calls the orm with the correct params", function()
                 Model.create({ first_name = 'roberto', last_name = 'gin' })
                 assert.are.same({ first_name = 'roberto', last_name = 'gin' }, attrs_arg)
+                assert.are.same("id", Model.__id_col)
+            end)
+
+            it("may use table_name .. '_id' as primary key", function()
+                Model = SqlOrm.define_model(MySql, 'users', true)
+                assert.are.same("users_id", Model.__id_col)
+            end)
+
+            it("may use an arbitrary column as primary key", function()
+                Model = SqlOrm.define_model(MySql, 'users', 'my_primary_column')
+                assert.are.same("my_primary_column", Model.__id_col)
             end)
 
             it("calls execute_and_return_last_id with the correct params", function()
@@ -101,6 +112,19 @@ describe("SqlOrm", function()
                 local model = Model.create({ first_name = 'roberto', last_name = 'gin' })
                 assert.are.same({ id = 10, first_name = 'roberto', last_name = 'gin' }, model)
             end)
+
+            it("returns a new model with table name based id", function()
+                Model = SqlOrm.define_model(MySql, 'users', true)
+                local model = Model.create({ first_name = 'roberto', last_name = 'gin' })
+                assert.are.same({ users_id = 10, first_name = 'roberto', last_name = 'gin' }, model)
+            end)
+
+            it("returns a new model with arbitrary id", function()
+                Model = SqlOrm.define_model(MySql, 'users', 'my_primary_column')
+                local model = Model.create({ first_name = 'roberto', last_name = 'gin' })
+                assert.are.same({ my_primary_column = 10, first_name = 'roberto', last_name = 'gin' }, model)
+            end)
+
         end)
 
         describe(".where", function()


### PR DESCRIPTION
This is a proposal to resolve https://github.com/ostinelli/gin/issues/15.
- it gracefully falls back to existing behaviour (default id column is `'id'`)
- it provides a simple mechanism to use `{tablename}_id` as primary key
- it provides a simple mechanism to use any arbitrary column as a primary key

Suitable test cases are included; documentation and versioning stuff are untouched on purpose to alleviate merging. NOTE: the overall testing for `execute_and_return_last_id` should be improved to cater for specific adapters. That is left over to a different branch after transforming tests to busted 2.0.
